### PR TITLE
fix(dismock): fix emoji url encoding bug

### DIFF
--- a/pkg/dismock/message_reaction.go
+++ b/pkg/dismock/message_reaction.go
@@ -18,13 +18,13 @@ import (
 // React mocks a React request.
 func (m *Mocker) React(channelID discord.ChannelID, messageID discord.MessageID, e api.Emoji) {
 	m.MockAPI("React", http.MethodPut,
-		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+url.PathEscape(e)+"/@me", nil)
+		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+e+"/@me", nil)
 }
 
 // Unreact mocks a Unreact request.
 func (m *Mocker) Unreact(channelID discord.ChannelID, messageID discord.MessageID, e api.Emoji) {
 	m.MockAPI("Unreact", http.MethodDelete,
-		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+url.PathEscape(e)+"/@me", nil)
+		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+e+"/@me", nil)
 }
 
 // Reactions mocks a Reactions request.
@@ -188,7 +188,7 @@ func (m *Mocker) reactionsRange(
 	}
 
 	m.MockAPI(name, http.MethodGet,
-		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+url.PathEscape(e),
+		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+e,
 		func(w http.ResponseWriter, r *http.Request, t *testing.T) {
 			expect := url.Values{
 				"limit": {strconv.FormatUint(uint64(limit), 10)},
@@ -217,13 +217,13 @@ func (m *Mocker) DeleteUserReaction(
 	}
 
 	m.MockAPI("DeleteUserReaction", http.MethodDelete,
-		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+url.PathEscape(e)+"/"+user, nil)
+		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+e+"/"+user, nil)
 }
 
 // DeleteReactions mocks a DeleteReactions request.
 func (m *Mocker) DeleteReactions(channelID discord.ChannelID, messageID discord.MessageID, e api.Emoji) {
 	m.MockAPI("DeleteReactions", http.MethodDelete,
-		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+url.PathEscape(e), nil)
+		"/channels/"+channelID.String()+"/messages/"+messageID.String()+"/reactions/"+e, nil)
 }
 
 // DeleteAllReactions mocks a DeleteAllReactions request.

--- a/pkg/dismock/message_reaction_test.go
+++ b/pkg/dismock/message_reaction_test.go
@@ -14,7 +14,7 @@ func TestMocker_React(t *testing.T) {
 	var (
 		channelID discord.ChannelID = 123
 		messageID discord.MessageID = 456
-		emoji                       = "abc"
+		emoji                       = "🍆"
 	)
 
 	m.React(channelID, messageID, emoji)
@@ -31,7 +31,7 @@ func TestMocker_Unreact(t *testing.T) {
 	var (
 		channelID discord.ChannelID = 123
 		messageID discord.MessageID = 456
-		emoji                       = "abc"
+		emoji                       = "🍆"
 	)
 
 	m.Unreact(channelID, messageID, emoji)
@@ -65,7 +65,7 @@ func TestMocker_Reactions(t *testing.T) {
 				var (
 					channelID discord.ChannelID = 123
 					messageID discord.MessageID = 456
-					emoji                       = "abc"
+					emoji                       = "🍆"
 				)
 
 				expect := []discord.User{ // more than 100 entries so multiple requests are mocked
@@ -122,7 +122,7 @@ func TestMocker_Reactions(t *testing.T) {
 		var (
 			channelID discord.ChannelID = 123
 			messageID discord.MessageID = 456
-			emoji                       = "abc"
+			emoji                       = "🍆"
 		)
 
 		var expect []discord.User
@@ -169,7 +169,7 @@ func TestMocker_ReactionsBefore(t *testing.T) {
 				var (
 					channelID discord.ChannelID = 123
 					messageID discord.MessageID = 456
-					emoji                       = "abc"
+					emoji                       = "🍆"
 
 					before discord.UserID = 999999999999
 				)
@@ -228,7 +228,7 @@ func TestMocker_ReactionsBefore(t *testing.T) {
 		var (
 			channelID discord.ChannelID = 123
 			messageID discord.MessageID = 456
-			emoji                       = "abc"
+			emoji                       = "🍆"
 		)
 
 		//noinspection GoPreferNilSlice
@@ -305,7 +305,7 @@ func TestMocker_ReactionsAfter(t *testing.T) {
 				var (
 					channelID discord.ChannelID = 123
 					messageID discord.MessageID = 456
-					emoji                       = "abc"
+					emoji                       = "🍆"
 
 					after discord.UserID = 123
 				)
@@ -364,7 +364,7 @@ func TestMocker_ReactionsAfter(t *testing.T) {
 		var (
 			channelID discord.ChannelID = 123
 			messageID discord.MessageID = 456
-			emoji                       = "abc"
+			emoji                       = "🍆"
 		)
 
 		var expect []discord.User
@@ -387,7 +387,7 @@ func TestMocker_ReactionsAfter(t *testing.T) {
 		var (
 			channelID discord.ChannelID = 123
 			messageID discord.MessageID = 456
-			emoji                       = "abc"
+			emoji                       = "🍆"
 		)
 
 		expect := []discord.User{
@@ -424,7 +424,7 @@ func TestMocker_DeleteUserReaction(t *testing.T) {
 		channelID discord.ChannelID = 123
 		messageID discord.MessageID = 456
 		userID    discord.UserID    = 789
-		emoji                       = "abc"
+		emoji                       = "🍆"
 	)
 
 	m.DeleteUserReaction(channelID, messageID, userID, emoji)
@@ -441,7 +441,7 @@ func TestMocker_DeleteReactions(t *testing.T) {
 	var (
 		channelID discord.ChannelID = 123
 		messageID discord.MessageID = 456
-		emoji                       = "abc"
+		emoji                       = "🍆"
 	)
 
 	m.DeleteReactions(channelID, messageID, emoji)


### PR DESCRIPTION
Fixes a bug, where arikawa did not encode Unicode emojis in paths, but dismock expected it to.