### PR TITLE
fix(github): run codecov also on pull request

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,6 +1,6 @@
 name: Codecov
 
-on: [push]
+on: [push,pull_request]
 
 jobs:
   codecov:


### PR DESCRIPTION
Run the codecov workflow also on pull request, to ensure that outside collaborations get scanned.